### PR TITLE
Fix compiler error about IDictionary 

### DIFF
--- a/dotnet/system/collections/generic/IDictionary.hx
+++ b/dotnet/system/collections/generic/IDictionary.hx
@@ -3,10 +3,12 @@ package dotnet.system.collections.generic;
 @:native("System.Collections.Generic.IDictionary")
 extern interface IDictionary<TKey,TValue> extends ICollection<KeyValuePair<TKey,TValue>> extends IEnumerable<KeyValuePair<TKey,TValue>> extends dotnet.system.collections.IEnumerable {
 
+  @:overload
   function Add(key:TKey, value:TValue) : Void;
 
   function ContainsKey(key:TKey) : Bool;
 
+  @:overload
   function Remove(key:TKey) : Bool;
 
   function TryGetValue(key:TKey, value:cs.Out<TValue>) : Bool;


### PR DESCRIPTION
```
$ haxe dotnet/system/collections/generic/IDictionary.hx -cs cs -D dll
dotnet/system/collections/generic/IDictionary.hx:4: lines 4-13 : Field Add has different type than in dotnet.system.collections.generic.ICollection
dotnet/system/collections/generic/IDictionary.hx:4: lines 4-13 : key : dotnet.system.collections.generic.IDictionary.TKey -> value : dotnet.system.collections.generic.IDictionary.TValue -> Void should be item : dotnet.system.collections.generic.KeyValuePair<dotnet.system.collections.generic.IDictionary.TKey, dotnet.system.collections.generic.IDictionary.TValue> -> Void
dotnet/system/collections/generic/IDictionary.hx:4: lines 4-13 : Field Remove has different type than in dotnet.system.collections.generic.ICollection
dotnet/system/collections/generic/IDictionary.hx:4: lines 4-13 : key : dotnet.system.collections.generic.IDictionary.TKey -> Bool should be item : dotnet.system.collections.generic.KeyValuePair<dotnet.system.collections.generic.IDictionary.TKey, dotnet.system.collections.generic.IDictionary.TValue> -> Bool
dotnet/system/collections/generic/IDictionary.hx:4: lines 4-13 : dotnet.system.collections.generic.IDictionary.TKey should be dotnet.system.collections.generic.KeyValuePair<dotnet.system.collections.generic.IDictionary.TKey, dotnet.system.collections.generic.IDictionary.TValue>
```
